### PR TITLE
typo fix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Example use as well as a list of available executors, commands, and jobs are ava
 
 ## Resources
 
-[CircleCI Orb Registry Page][reg-page] - The official registry page for this orb will all versions, executors, commands, and jobs described.  
+[CircleCI Orb Registry Page][reg-page] - The official registry page for this orb with all versions, executors, commands, and jobs described.  
 [CircleCI Orb Docs](https://circleci.com/docs/2.0/orb-intro/#section=configuration) - Docs for using and creating CircleCI Orbs.  
 
 


### PR DESCRIPTION
changed will -> with.
it makes sense to say that the circleci orb registry page is 'with all versions, executors, commands, and jobs described.' 